### PR TITLE
Only use short-circuiting operators in VB.NET.

### DIFF
--- a/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperators.cs
+++ b/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperators.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Common.Sqale;
+using SonarAnalyzer.Helpers;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace SonarAnalyzer.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+    [SqaleConstantRemediation("5min")]
+    [SqaleSubCharacteristic(SqaleSubCharacteristic.Understandability)]
+    [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
+    [Tags(Tag.Suspicious, Tag.Performance)]
+    public class UseShortCircuitingOperators : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "?XXX";
+        internal const string Title = "Only use short-circuiting operators";
+        internal const string Description =
+            "Only use short-circuiting operators, as further analyzing the expression will not change the outcome.";
+        internal const string MessageFormat = "Use the short-circuiting alternative {0}.";
+        internal const string Category = SonarAnalyzer.Common.Category.Performance;
+        internal const Severity RuleSeverity = Severity.Major;
+        internal const bool IsActivatedByDefault = true;
+        private const IdeVisibility ideVisibility = IdeVisibility.Hidden;
+
+        internal static readonly DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category,
+                RuleSeverity.ToDiagnosticSeverity(ideVisibility), IsActivatedByDefault,
+                helpLinkUri: DiagnosticId.GetHelpLink(),
+                description: Description,
+                customTags: ideVisibility.ToCustomTags());
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(DetectUsageOfNonShortCircuitingOperators,
+                SyntaxKind.AndExpression,
+                SyntaxKind.OrExpression);
+        }
+
+        private void DetectUsageOfNonShortCircuitingOperators(SyntaxNodeAnalysisContext context)
+        {
+            var alternative = ShortCircuitingAlternative[context.Node.Kind()];
+            context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(), alternative));
+        }
+
+        private readonly Dictionary<SyntaxKind, SyntaxKind> ShortCircuitingAlternative = new Dictionary<SyntaxKind, SyntaxKind>()
+        {
+            { SyntaxKind.AndExpression,SyntaxKind.AndAlsoExpression },
+            { SyntaxKind.OrExpression,SyntaxKind.OrElseExpression },
+        };
+    }
+}

--- a/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperatorsFixProvider.cs
+++ b/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperatorsFixProvider.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Helpers;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SonarAnalyzer.Rules
+{
+    [ExportCodeFixProvider(LanguageNames.VisualBasic)]
+    public class UseShortCircuitingOperatorsFixProvider : SonarCodeFixProvider
+    {
+        internal const string Title = "Use short-circuiting operators";
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get
+            {
+                return ImmutableArray.Create(UseShortCircuitingOperators.DiagnosticId);
+            }
+        }
+
+        protected override async Task RegisterCodeFixesAsync(SyntaxNode root, CodeFixContext context)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(Title, c => ReplaceOperator(root, context), Title),
+                context.Diagnostics);
+        }
+
+        private Task<Document> ReplaceOperator(SyntaxNode root, CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var node = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true) as BinaryExpressionSyntax;
+            var replacement = GetShortCircuitingExpressionNode(node);
+            var newRoot = root.ReplaceNode(node, replacement);
+            return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+        }
+
+        private SyntaxNode GetShortCircuitingExpressionNode(BinaryExpressionSyntax node)
+        {
+            var kind = node.Kind();
+            if(kind == SyntaxKind.AndExpression)
+            {
+                return SyntaxFactory.AndAlsoExpression(node.Left, node.Right);
+            }
+            if(kind == SyntaxKind.OrExpression)
+            {
+                return SyntaxFactory.OrElseExpression(node.Left, node.Right);
+            }
+            return node;
+        }
+    }
+}

--- a/src/Tests/SonarAnalyzer.UnitTest/Rules/UseShortCircuitingOperatorsTest.cs
+++ b/src/Tests/SonarAnalyzer.UnitTest/Rules/UseShortCircuitingOperatorsTest.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2016 SonarSource SA
+ * mailto:contact@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules;
+using SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class UseShortCircuitingOperatorsTest
+    {
+        [TestMethod, TestCategory("Rule")]
+        public void UseShortCircuitingOperators()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\UseShortCircuitingOperators.vb", new UseShortCircuitingOperators());
+        }
+
+        [TestMethod, TestCategory("CodeFix")]
+        public void UseShortCircuitingOperators_CodeFix()
+        {
+            Verifier.VerifyCodeFix(
+                @"TestCases\UseShortCircuitingOperators.vb",
+                @"TestCases\UseShortCircuitingOperators.Fixed.vb",
+                new UseShortCircuitingOperators(),
+                new UseShortCircuitingOperatorsFixProvider());
+        }
+    }
+}

--- a/src/Tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/src/Tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -157,7 +157,205 @@
     <None Include="TestCases\*.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="TestCases\*.vb">
+    <None Include="TestCases\ArrayCreationLongSyntax.Fixed.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ArrayCreationLongSyntax.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ArrayDesignatorOnVariable.Fixed.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ArrayDesignatorOnVariable.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ArrayInitializationMultipleStatements.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\BinaryOperationWithIdenticalExpressions.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ClassName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\CommentLineEnd.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ConditionalStructureSameCondition.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ConditionalStructureSameImplementation_If.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ConditionalStructureSameImplementation_Switch.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EndStatementUsage.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EnumerationName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EnumerationValueName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EnumNameHasEnumSuffix.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EventHandlerName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EventName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\EventNameContainsBeforeOrAfter.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ExitStatementUsage.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ExpressionComplexity.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FieldShouldNotBePublic.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FileLines12.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FileLines13.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FlagsEnumWithoutInitializer.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FlagsEnumZeroMember.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FunctionComplexity.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FunctionName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\FunctionNestingDepth.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\IndexedPropertyName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\IndexedPropertyWithMultipleParameters.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\InterfaceName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\LineContinuation.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\LineLength.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\LocalVariableName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\MultipleVariableDeclaration.Fixed.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\MultipleVariableDeclaration.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\NamespaceName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\NegatedIsExpression.Fixed.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\NegatedIsExpression.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\OnErrorStatement.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\OptionalParameter.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ParameterAssignedTo.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ParameterName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PrivateConstantFieldName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PrivateFieldName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PrivateSharedReadonlyFieldName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PropertyGetterWithThrow.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PropertyName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PropertyWithArrayType.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PropertyWriteOnly.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PublicConstantField.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PublicConstantFieldName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PublicFieldName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PublicMethodWithMultidimensionalArray.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\PublicSharedReadonlyFieldName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\RedundantExitSelect.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\SelfAssignment.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\SimpleDoLoop.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\SingleStatementPerLine.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\StringConcatenationInLoop.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\StringConcatenationWithPlus.Fixed.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\StringConcatenationWithPlus.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\SwitchWithoutDefault.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\TabCharacter.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\TypeParameterName.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\UnsignedTypesUsage.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\UseWithStatement.vb">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestCasesForRuleFailure\*.cs">
@@ -199,6 +397,16 @@
       <Project>{d1ae804f-ae78-4883-b3d6-9e3c4026def6}</Project>
       <Name>SonarAnalyzer.Common</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestCases\UseShortCircuitingOperators.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestCases\UseShortCircuitingOperators.Fixed.vb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseShortCircuitingOperators.Fixed.vb
+++ b/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseShortCircuitingOperators.Fixed.vb
@@ -1,0 +1,39 @@
+﻿Public Class ClassWithLogicalStatements
+
+	Public Function [And](first As Boolean, second As Boolean) As Boolean
+
+		If first AndAlso second Then 'Fixed
+			Return True
+		End If
+		Return False
+
+	End Function
+
+	Public Function [AndAlso](first As Boolean, second As Boolean) As Boolean
+
+		If first AndAlso second Then 'Compliant, using AndAlso.
+			Return True
+		End If
+		Return False
+
+	End Function
+
+	Public Function [Or](first As Boolean, second As Boolean) As Boolean
+
+		If first OrElse second Then 'Fixed
+			Return True
+		End If
+		Return False
+
+	End Function
+
+	Public Function [OrElse](first As Boolean, second As Boolean) As Boolean
+
+		If first OrElse second Then 'Compliant, using OrElse.
+			Return True
+		End If
+		Return False
+
+	End Function
+
+End Class

--- a/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseShortCircuitingOperators.vb
+++ b/src/Tests/SonarAnalyzer.UnitTest/TestCases/UseShortCircuitingOperators.vb
@@ -1,0 +1,39 @@
+﻿Public Class ClassWithLogicalStatements
+
+	Public Function [And](first As Boolean, second As Boolean) As Boolean
+
+		If first And second Then 'Noncompliant, should use AndAlso.
+			Return True
+		End If
+		Return False
+
+	End Function
+
+	Public Function [AndAlso](first As Boolean, second As Boolean) As Boolean
+
+		If first AndAlso second Then 'Compliant, using AndAlso.
+			Return True
+		End If
+		Return False
+
+	End Function
+
+	Public Function [Or](first As Boolean, second As Boolean) As Boolean
+
+		If first Or second Then 'Noncompliant, should use OrElse.
+			Return True
+		End If
+		Return False
+
+	End Function
+
+	Public Function [OrElse](first As Boolean, second As Boolean) As Boolean
+
+		If first OrElse second Then 'Compliant, using OrElse.
+			Return True
+		End If
+		Return False
+
+	End Function
+
+End Class


### PR DESCRIPTION
Only use short-circuiting operators, as further analyzing the expression will not change the outcome. It is a typical VB.NET issue, as the none short-circuiting keywords are the default onces.
